### PR TITLE
wide review "at least 3 months before CR"

### DIFF
--- a/milestones/index.html
+++ b/milestones/index.html
@@ -86,7 +86,7 @@ rec
        Last day to set  the <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> used for the 150 days exclusion opportunity started earlier.<br>
        <span class='date'></span>
     </li>
-    <li class='exact' data-day='-28' data-base='cr' id="wide-review-comments">
+    <li class='exact' data-day='-90' data-base='cr' id="wide-review-comments">
         Latest date to request <a href='https://www.w3.org/Consortium/Process/#wide-review'>wide review</a> of the Working Draft<br>
           <span class='date'></span>
     </li>


### PR DESCRIPTION
Per
  https://rawgit.com/w3c/charter-drafts/gh-pages/charter-template.html

This moves back the last date to do wide review by an additional 2 months (from 28 days to 90 days before the CR gets published).

Fixes #3

for review/comments: @nigelmegitt @r12a @michael-n-cooper @swickr 
