### PR TITLE
Remove live region markup

### DIFF
--- a/milestones/index.html
+++ b/milestones/index.html
@@ -71,7 +71,7 @@ rec
   only-tuesday-thursday
 
   -->
-  <ul id='steps'  aria-live="polite" aria-atomic="true">
+  <ul id='steps'>
     <li class='exact' data-day='-17' data-base='fpwd' id='group_fpwd_decision'>
       <a href='https://w3c.github.io/charter-drafts/charter-template.html#decisions'>Group Call for Consensus (CfC)</a> to move to First Public Working Draft<br>
       <span class='date'></span>

--- a/milestones/index.html
+++ b/milestones/index.html
@@ -71,7 +71,7 @@ rec
   only-tuesday-thursday
 
   -->
-  <ul id='steps'  aria-live="assertive" aria-atomic="true">
+  <ul id='steps'  aria-live="polite" aria-atomic="true">
     <li class='exact' data-day='-17' data-base='fpwd' id='group_fpwd_decision'>
       <a href='https://w3c.github.io/charter-drafts/charter-template.html#decisions'>Group Call for Consensus (CfC)</a> to move to First Public Working Draft<br>
       <span class='date'></span>


### PR DESCRIPTION
Hello @deniak  @plehegar 

I would remove this ARIA markup. It causes a conflict when using the date pickers with screen readers. The whole contents of `<ul id='steps'>` are announced before the selected day/month/year, which makes using the pickers quite an inefficient experience. I apprecieate the intent to make screen reader users aware of the changes in the different milestones as you move through the calendar, but I think a better experience is for the user to first select the date they want and then to review the changes in the other milestones by themselves using regular screen reader navigation commands.